### PR TITLE
Add Nginx timeout config to deployments

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -139,6 +139,8 @@ spec:
             value: /etc/nginx/secrets/pttg-rps-api-bundle.pem
           - name: SERVER_KEY
             value: /etc/nginx/secrets/pttg-rps-api-key.pem
+          - name: ADD_NGINX_LOCATION_CFG
+            value: 'proxy_read_timeout 99999s; proxy_connect_timeout 60s;'
         volumeMounts:
           - name: secrets
             mountPath: /etc/nginx/secrets


### PR DESCRIPTION
This to bring RPS-API inline with the other services and have its own Nginx timeout config. 